### PR TITLE
Document tagging metadata update (#194)

### DIFF
--- a/aws-ssm-maintenancewindowtarget/src/test/java/software/amazon/ssm/maintenancewindowtarget/CreateHandlerTest.java
+++ b/aws-ssm-maintenancewindowtarget/src/test/java/software/amazon/ssm/maintenancewindowtarget/CreateHandlerTest.java
@@ -29,8 +29,8 @@ import software.amazon.ssm.maintenancewindowtarget.translator.ExceptionTranslato
 
 import java.util.function.Function;
 
-import static junit.framework.Assert.assertEquals;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;

--- a/aws-ssm-maintenancewindowtask/src/test/java/software/amazon/ssm/maintenancewindowtask/CreateHandlerTest.java
+++ b/aws-ssm-maintenancewindowtask/src/test/java/software/amazon/ssm/maintenancewindowtask/CreateHandlerTest.java
@@ -27,8 +27,8 @@ import software.amazon.ssm.maintenancewindowtask.util.ResourceHandlerRequestToSt
 
 import java.util.function.Function;
 
-import static junit.framework.Assert.assertEquals;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/aws-ssm-resourcedatasync/aws-ssm-resourcedatasync.json
+++ b/aws-ssm-resourcedatasync/aws-ssm-resourcedatasync.json
@@ -151,6 +151,9 @@
     "readOnlyProperties": [
         "/properties/SyncName"
     ],
+    "tagging": {
+        "taggable": "true"
+    },
     "handlers": {
         "create": {
             "permissions": [

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -7,6 +7,7 @@ phases:
     commands:
       - pip install --upgrade 'six==1.16.0'
       - pip install --upgrade 'requests>=2.26.0'
+      - pip install --upgrade 'urllib3>=1.26.0'
       - pip install pre-commit cloudformation-cli-java-plugin
       - pip install pyyaml --upgrade
       - pip install boto3 --upgrade


### PR DESCRIPTION
* Support YAML ObjectMapper when DocumentFormat YAML specified

* Add tagging in document metadata shcema

* Fix ssm maintenancewindowtask CreateHandler test import

* Add urllib3 version requirement to mitigate docker build issue

* Fix ssm maintenancewindowtarget CreateHandler test import

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
